### PR TITLE
optionally customize block layout via env vars, docker kill stop signal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-alpine
 
+STOPSIGNAL SIGKILL
+
 COPY telnetris.js /app/
 EXPOSE 10023
 USER nobody:nobody

--- a/telnetris.js
+++ b/telnetris.js
@@ -42,9 +42,9 @@ var ESC = String.fromCharCode(0x1B);
 
 
 // Block layout customization
-var BLOCK_FALLING = process.env.BLOCK_FALLING || "<>";
-var BLOCK_BOTTOM  = process.env.BLOCK_BOTTOM  || "[]";
-var BLOCK_BACKGROUND = process.env.BLOCK_BACKGROUND || "  ";
+var BLOCK_FALLING = process.env.BLOCK_FALLING.slice(0, 2) || "<>";
+var BLOCK_BOTTOM  = process.env.BLOCK_BOTTOM.slice(0, 2)  || "[]";
+var BLOCK_BACKGROUND = process.env.BLOCK_BACKGROUND.slice(0, 2) || "  ";
 
 /**
  * Telnetris Game class

--- a/telnetris.js
+++ b/telnetris.js
@@ -42,9 +42,9 @@ var ESC = String.fromCharCode(0x1B);
 
 
 // Block layout customization
-var BLOCK_FALLING = process.env.BLOCK_FALLING.slice(0, 2) || "<>";
-var BLOCK_BOTTOM  = process.env.BLOCK_BOTTOM.slice(0, 2)  || "[]";
-var BLOCK_BACKGROUND = process.env.BLOCK_BACKGROUND.slice(0, 2) || "  ";
+var BLOCK_FALLING = process.env.BLOCK_FALLING || "<>";
+var BLOCK_BOTTOM  = process.env.BLOCK_BOTTOM  || "[]";
+var BLOCK_BACKGROUND = process.env.BLOCK_BACKGROUND || "  ";
 
 /**
  * Telnetris Game class

--- a/telnetris.js
+++ b/telnetris.js
@@ -41,6 +41,11 @@ var SUPPRESS_GO_AHEAD = 3;
 var ESC = String.fromCharCode(0x1B);
 
 
+// Block layout customization
+var BLOCK_FALLING = process.env.BLOCK_FALLING || "<>";
+var BLOCK_BOTTOM  = process.env.BLOCK_BOTTOM  || "[]";
+var BLOCK_BACKGROUND = process.env.BLOCK_BACKGROUND || "  ";
+
 /**
  * Telnetris Game class
  *
@@ -230,13 +235,13 @@ var Game = function (socket, num) {
                     j >= _this.currentBlock.x && j < _this.currentBlock.x + _this.currentBlock.width &&
                     _this.currentBlock.type[i - _this.currentBlock.y][j - _this.currentBlock.x]) {
 
-                    line += "<>";
+                    line += BLOCK_FALLING;
 
                 } else if (_this.field[i][j]) {
-                    line += "[]";
+                    line += BLOCK_BOTTOM;
 
                 } else {
-                    line += "  ";
+                    line += BLOCK_BACKGROUND;
                 }
             }
 
@@ -257,7 +262,7 @@ var Game = function (socket, num) {
                 line += "\t  ";
                 for (j = 0; j < 4; j++) {
                     if (_this.scheduledBlock.type[i - 10] && _this.scheduledBlock.type[i - 10][j])
-                        line += "<>";
+                        line += BLOCK_FALLING;
                     else
                         line += "  ";
                 }
@@ -277,7 +282,7 @@ var Game = function (socket, num) {
         line = "\r\n\t+";
         for (i = 0; i < 10; i++) {
             if (i >= _this.currentBlock.x && i < _this.currentBlock.x + _this.currentBlock.width)
-                line += "  ";
+                line += BLOCK_BACKGROUND;
             else
                 line += "--";
         }


### PR DESCRIPTION
1.

Allow users to replace block characters, e.g.:

`docker run -e BLOCK_FALLING='{}' -e BLOCK_BOTTOM="[]" -e BLOCK_BACKGROUND=".." ...`

Not stupid-safe as it does not validate the string length to be exactly 2.


2.
container does not exit for SIGTERM due to sockets. changing stop signal to kill.